### PR TITLE
🐛 [FIX] ci/cd spring server 실행 오류

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
 	//security
-	compileOnly 'org.springframework.boot:spring-boot-starter-security'
-
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 
 	//s3

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,9 +3,10 @@ spring:
     activate:
       on-profile: local # 환경 이름 설정
   datasource:
-    url: jdbc:mysql://localhost:3306/irecipe
+    # url: jdbc:mysql://localhost:3306/irecipe
+    url: jdbc:mysql://irecipedb.c5qwe0s82tjq.ap-northeast-2.rds.amazonaws.com:3306/irecipe?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
-    password: eldnj521!
+    password: irecipedb
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql:
     init:


### PR DESCRIPTION
- close #46 
## 📃 작업 내용
- ERROR EC2RoleProvider Failed to connect to Systems Manager with SSM role credentials. error calling RequestManagedInstanceRoleToken: AccessDeniedException: Systems Manager's instance management role is not configured for account: 654654538000
-> AWS IAM 권한 추가
![image](https://github.com/IRECIPE/IRecipe-Server/assets/90559205/77f964de-9082-4da0-927d-995f66cd9d46)


- Caused by: java.lang.ClassNotFoundException: org.springframework.security.config.annotation.web.builders.WebSecurity
-> build.gradle 스프링 시큐리티 compileOnly -> implementation 변경


- com.mysql.cj.jdbc.exceptions.CommunicationsException: Communications link failure
-> RDS 연결로 변경